### PR TITLE
Fixing bug with 0s returned from sensor on first request.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,11 +28,11 @@
 			"preLaunchTask": "publish",
 			"program": "/home/pi/.dotnet/dotnet",
 			"args": [
-				"/home/pi/app/net5.0/WebApp.dll",
+				"/home/pi/app/WebApp.dll",
 				"--urls",
 				"http://raspberrypi:8080"
 			],
-			"cwd": "/home/pi/app/net5.0",
+			"cwd": "/home/pi/app",
 			"stopAtEntry": false,
 			"console": "internalConsole",
 			"launchBrowser": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,7 @@
 			"command": "scp",
 			"args": [
 				"-r",
-				"${workspaceFolder}/src/WebApp/bin/Debug/net5.0",
+				"${workspaceFolder}/src/WebApp/bin/Debug/net5.0/*",
 				"pi@raspberrypi:/home/pi/app/"
 			],
 			"presentation": {

--- a/src/Adafruit.Devices.Veml7700/Adafruit_VEML7700.cs
+++ b/src/Adafruit.Devices.Veml7700/Adafruit_VEML7700.cs
@@ -84,6 +84,21 @@ namespace Adafruit.Devices.Veml7700
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
+        ~Adafruit_VEML7700() {
+            Dispose(false);
+        }
+
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing) {
+            if (disposing) {
+                device.Dispose();
+            }
+        }
+
         public void Init()
         {
             if (initialized)

--- a/src/Adafruit.Devices.Veml7700/FakeAdafruit_VEML7700.cs
+++ b/src/Adafruit.Devices.Veml7700/FakeAdafruit_VEML7700.cs
@@ -24,9 +24,21 @@ namespace Adafruit.Devices.Veml7700
             this.readWhiteNormalizedValue = readWhiteNormalizedValue;
         }
 
+        ~FakeAdafruit_VEML7700() {
+            Dispose(false);
+        }
+
         public bool IsEnabled { get; set; }
         public GainLevel Gain { get; set; }
         public IntegrationTime IntegrationTime { get; set; }
+
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing) {
+        }
 
         public void Init()
         {

--- a/src/Adafruit.Devices.Veml7700/IAdafruit_VEML7700.cs
+++ b/src/Adafruit.Devices.Veml7700/IAdafruit_VEML7700.cs
@@ -2,12 +2,14 @@
 // https://github.com/adafruit/Adafruit_BusIO/blob/master/Adafruit_BusIO_Register.h
 // https://learn.adafruit.com/adafruit-veml7700/arduino
 
+using System;
+
 namespace Adafruit.Devices.Veml7700
 {
     /// <summary>
     /// Identifies a device driver for the Adafruit VEML7700.
     /// </summary>
-    public interface IAdafruit_VEML7700 { 
+    public interface IAdafruit_VEML7700 : IDisposable { 
         bool IsEnabled { get; set; }
         GainLevel Gain { get; set; }
         IntegrationTime IntegrationTime { get; set; }

--- a/src/Adafruit.Devices.Veml7700/II2cDevice.cs
+++ b/src/Adafruit.Devices.Veml7700/II2cDevice.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace System.Device.I2c
 {
-    public interface II2cDevice {
+    public interface II2cDevice : IDisposable {
         byte ReadByte();
         void Read(Span<byte> buffer);
 

--- a/src/Adafruit.Devices.Veml7700/Primitives/I2cBusWrapper.cs
+++ b/src/Adafruit.Devices.Veml7700/Primitives/I2cBusWrapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Device.I2c;
 
 namespace Adafruit.Devices.Primitives
@@ -10,9 +11,17 @@ namespace Adafruit.Devices.Primitives
         }
 
         public II2cDevice CreateDevice(int deviceAddress) {
-            var device = bus.CreateDevice(deviceAddress);
+            I2cDevice device = null;
+            
+            try {
+                device = bus.CreateDevice(deviceAddress);
 
-            return new I2cDeviceWrapper(device);
+                return new I2cDeviceWrapper(device);                
+            }
+            catch (Exception) {
+                device?.Dispose();
+                throw;
+            }
         }
     }
 }

--- a/src/Adafruit.Devices.Veml7700/Primitives/I2cDeviceWrapper.cs
+++ b/src/Adafruit.Devices.Veml7700/Primitives/I2cDeviceWrapper.cs
@@ -9,9 +9,23 @@ namespace Adafruit.Devices.Primitives
 
         public I2cDeviceWrapper(I2cDevice device)
         {
-            this.device = device;
+            this.device = device ?? throw new ArgumentNullException(nameof(device));
         }
 
+        ~I2cDeviceWrapper() {
+            Dispose(false);
+        }
+
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing) {
+            if (disposing) {
+                device.Dispose();
+            }
+        }
         public byte ReadByte()
         {
             return device.ReadByte();

--- a/src/WebApp/Infrastructure/Factories/Veml7700DriverFactory.cs
+++ b/src/WebApp/Infrastructure/Factories/Veml7700DriverFactory.cs
@@ -8,12 +8,12 @@ using Microsoft.Extensions.Logging;
 using WebApp.Exceptions;
 
 namespace WebApp.Infrastructure.Factories {
-    class Veml7700DriverFactory : IVeml7700DriverFactory
+    class Veml7700DriverFactory : IVeml7700DriverFactory 
     {
         private readonly ILoggerFactory loggerFactory;
         private readonly II2cBus bus;
         private readonly IConfiguration configuration;
-        private readonly Dictionary<int, IAdafruit_VEML7700> devices = new Dictionary<int, IAdafruit_VEML7700>();
+        private readonly Dictionary<int, Adafruit_VEML7700> devices = new Dictionary<int, Adafruit_VEML7700>();
 
         public Veml7700DriverFactory(ILoggerFactory loggerFactory, II2cBus bus, IConfiguration configuration) {
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
@@ -21,15 +21,14 @@ namespace WebApp.Infrastructure.Factories {
             this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
         
-        public IAdafruit_VEML7700 Create(int deviceAddress)
-        {
+        public IAdafruit_VEML7700 Create(int deviceAddress) {
             var driver = GetDeviceById(deviceAddress);				
             var options = configuration.GetVeml7700Options();
 
-			driver.IsEnabled = true;
 			driver.Gain = options.Gain;
 			driver.IntegrationTime = options.IntegrationTime;
-
+			driver.IsEnabled = true;
+            
 			return driver;
         }
 
@@ -44,13 +43,17 @@ namespace WebApp.Infrastructure.Factories {
                     loggerFactory.CreateLogger<Adafruit_VEML7700>());
                             
                 device.Init();
-
-                devices.Add(deviceAddress, device);
-                return device;
             }
             catch (IOException ex) {
-                throw new DeviceNotFoundException(deviceAddress, ex);
+                device?.Dispose();
+
+                throw new DeviceNotFoundException(
+                    deviceAddress, 
+                    ex);
             }
+
+            devices.Add(deviceAddress, device);
+            return device;
         }
     }
 }


### PR DESCRIPTION
The issue seemed to be when the driver was being enabled, and the other settings were being set after it was turned on. This likely caused it to restart on first request internally.

Resolves #15 